### PR TITLE
added project locking mechanism

### DIFF
--- a/assets.go
+++ b/assets.go
@@ -202,12 +202,17 @@ func listAssets(cmd *cli.Cmd) {
 }
 
 func addAsset(cmd *cli.Cmd) {
-	cmd.Spec = "--project --file"
+	cmd.Spec = "[--project] --file"
 	name := cmd.StringOpt("project p", "", "Name (or part of it) of a project")
 	file := cmd.StringOpt("file f", "", "path to the file which you want as an asset")
 
 	cmd.Action = func() {
 		*name = strings.TrimSpace(*name)
+
+		if *name == "" {
+			*name, _ = ReadProjectLock()
+		}
+
 		// first get the project, then get the pid, and make the call.
 		p, err := chooseProject(*name, "Add asset to: ")
 		if err != nil {
@@ -231,6 +236,10 @@ func removeAsset(cmd *cli.Cmd) {
 
 	cmd.Action = func() {
 		*name = strings.TrimSpace(*name)
+		if *name == "" {
+			*name, _ = ReadProjectLock()
+		}
+
 		var ass *Asset
 		var err error
 		if *all || *name == "" {

--- a/jobs.go
+++ b/jobs.go
@@ -187,6 +187,9 @@ func jobStatusProject(cmd *cli.Cmd) {
 
 	cmd.Action = func() {
 		*name = strings.TrimSpace(*name)
+		if *name == "" {
+			*name, _ = ReadProjectLock()
+		}
 		if *all || *name == "" {
 			chooseJob("/v1/jobs", false, "")
 			return
@@ -208,8 +211,11 @@ func jobStatusProject(cmd *cli.Cmd) {
 }
 
 func buildProject(cmd *cli.Cmd) {
-	cmd.Spec = "--project"
+	cmd.Spec = "[--project]"
 	name := cmd.StringOpt("project p", "", "Name (or part of it) of a project")
+	if *name == "" {
+		*name, _ = ReadProjectLock()
+	}
 
 	cmd.Action = func() {
 		postNewJOB("build", strings.TrimSpace(*name))
@@ -217,8 +223,11 @@ func buildProject(cmd *cli.Cmd) {
 }
 
 func validateProject(cmd *cli.Cmd) {
-	cmd.Spec = "--project"
+	cmd.Spec = "[--project]"
 	name := cmd.StringOpt("project p", "", "Name (or part of it) of a project")
+	if *name == "" {
+		*name, _ = ReadProjectLock()
+	}
 
 	cmd.Action = func() {
 		postNewJOB("validate", strings.TrimSpace(*name))

--- a/projects.go
+++ b/projects.go
@@ -174,11 +174,14 @@ func createProject(cmd *cli.Cmd) {
 }
 
 func settingsProject(cmd *cli.Cmd) {
-	cmd.Spec = "--name KEY VALUE"
+	cmd.Spec = "[--name] KEY VALUE"
 	name := cmd.StringOpt("name", "", "Name for the project")
 	key := cmd.StringArg("KEY", "", "Name of the setting")
 	value := cmd.StringArg("VALUE", "", "Value of the setting")
 	cmd.Action = func() {
+		if *name == "" {
+			*name, _ = ReadProjectLock()
+		}
 		p, err := chooseProject(*name, "Which project needs to be updated: ")
 		if err == nil {
 			resp, err := Do(p.EndPoint(), "PUT", createProjectParam("", "", fmt.Sprintf(`{"%s": "%s"}`, *key, *value)))

--- a/utils.go
+++ b/utils.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bufio"
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -103,4 +105,21 @@ func TerminalWidth() int {
 	}
 
 	return width
+}
+
+// looks in current directory for a file `.slyftproject`,
+// reads the first line and returns it (as a replacename
+// for --name parameter whereever a project name is required)
+func ReadProjectLock() (string, error) {
+	f, err := os.Open(".slyftproject")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	if scanner.Scan() {
+		return scanner.Text(), nil
+	}
+	return "", errors.New("NoProjectLock")
 }


### PR DESCRIPTION
Many commands require a `--name` or `--project` to specify which project to use. To make usage easier, the user may place a file `slyftproject` in $PWD. If no project name parameter is given, this file is read and taken as the project name parameter.

Since most of work is done within a project directory, all slyft calls are related to the project where user stands in.