### PR TITLE
detect UTF-16 and UTF-32 BOMs

### DIFF
--- a/preflight_test.go
+++ b/preflight_test.go
@@ -9,7 +9,7 @@ func TestPreflightAsset(t *testing.T) {
 	yamlFileMock := "mock.yaml"
 	ramlFileMock := "mock.raml"
 
-	//byte slices
+	//byte arrays
 	invalidUtf8 := []byte{0xff, 0xfe, 0xfd}
 	xmlMarkup := []byte("<?xml version='1.0' encoding='UTF-8' standalone='yes'?><root/>")
 	validJson := []byte("{ \"foo\": [\"bar\", \"barfoo\"] }")


### PR DESCRIPTION
Added detection for UTF-16 and UTF-32 BOMs so UTF-8 validation doesn't flag valid UTF-16 and UTF-32 assets as invalid.
