### PR TITLE
show error message if any in asset response

### DIFF
--- a/duplicated.go
+++ b/duplicated.go
@@ -31,7 +31,7 @@ func extractAssetFromResponse(resp *http.Response, expectedCode int, listExpecte
 	}
 
 	if resp.StatusCode != expectedCode {
-		return nil, errors.New(fmt.Sprintf("Failed with the wrong code: %v. (expected %v)\n", resp.StatusCode, expectedCode))
+		return nil, errors.New(fmt.Sprintf("Failed with the wrong code: %v. (expected %v)\nErrors: %s\n", resp.StatusCode, expectedCode, body))
 	}
 
 	if listExpected {


### PR DESCRIPTION
the API returns error messages in a JSON array in case that the API call is unsuccesful.
At least show the errors on the CLI.

ideally this can get parsed a bit more beautifully, currently it is shown as:
`{"errors":{"name":["should be unique per project"]}}`